### PR TITLE
Use parameterized queries instead of string formatting.

### DIFF
--- a/associationtrainer.py
+++ b/associationtrainer.py
@@ -35,20 +35,20 @@ def train_association(word, associationType, target):
 
         # Check to see if the association already exists
         with connection:
-            cursor.execute('SELECT * FROM associationmodel WHERE word = \"{0}\" AND association_type = \"{1}\" AND target = \"{2}\";'.format(word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore')))
+            cursor.execute('SELECT * FROM associationmodel WHERE word = ? AND association_type = ? AND target = ?;', (word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore')))
             SQLReturn = cursor.fetchall()
             if SQLReturn:
                 # Association already exists, so we strengthen it
                 weight = calculate_new_weight(SQLReturn[0][3])
                 with connection:
-                    cursor.execute('UPDATE associationmodel SET weight = \"{0}\" WHERE word = \"{1}\" AND association_type = \"{2}\" AND target = \"{3}\";'.format(weight, word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore')))
+                    cursor.execute('UPDATE associationmodel SET weight = ? WHERE word = ? AND association_type = ? AND target = ?;', (weight, word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore')))
                 logging.info("Strengthened association \"{0} {1} {2}\"".format(word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore')))
             else:
                 # Association does not exist, so add it
                 # This is the weight calculated for all new associations
                 weight = 0.0999999999997
                 with connection:
-                    cursor.execute('INSERT INTO associationmodel(word, association_type, target, weight) VALUES (\"{0}\", \"{1}\", \"{2}\", \"{3}\");'.format(word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore'), weight))
+                    cursor.execute('INSERT INTO associationmodel(word, association_type, target, weight) VALUES (?, ?, ?, ?);', (word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore'), weight))
                 logging.info("Found new association \"{0} {1} {2}\"".format(word.encode('utf-8', 'ignore'), associationType, target.encode('utf-8', 'ignore')))
 
 def find_associations(message):

--- a/emma.py
+++ b/emma.py
@@ -282,7 +282,7 @@ def train(message):
                         logging.debug("Prev. word POS: \'{0}\'".format(word.partOfSpeech))
                         knownWords.append((word.lemma, word.partOfSpeech))
                         with connection:
-                            cursor.execute('INSERT INTO dictionary VALUES (\"{0}\", \"{1}\", 0);'.format(re.escape(word.lemma.encode('utf-8', 'ignore')), word.partOfSpeech))
+                            cursor.execute('INSERT INTO dictionary VALUES (?, ?, 0);', (re.escape(word.lemma.encode('utf-8', 'ignore')), word.partOfSpeech))
 
     logging.info("Finding associations...")
     associationtrainer.find_associations(message)

--- a/replybuilder.py
+++ b/replybuilder.py
@@ -23,7 +23,7 @@ class SBBWord:
         self.partOfSpeech = str
 
         with connection:
-            cursor.execute('SELECT part_of_speech FROM dictionary WHERE word = \"{0}\";'.format(self.word))
+            cursor.execute('SELECT part_of_speech FROM dictionary WHERE word = ?;', (self.word,))
             SQLReturn = cursor.fetchall()
             self.partOfSpeech = SQLReturn[0]
 
@@ -71,7 +71,7 @@ def find_associations(keyword):
     logging.debug("Finding associations for {0}...".format(keyword)) 
     associations = []
     with connection:
-        cursor.execute('SELECT * FROM associationmodel WHERE word = \"{0}\" OR target = \"{1}\";'.format(keyword, keyword))
+        cursor.execute('SELECT * FROM associationmodel WHERE word = ? OR target = ?;', (keyword, keyword))
         SQLReturn = cursor.fetchall()
         for row in SQLReturn:
             associations.append(Association(row[0], row[1], row[2], row[3]))
@@ -82,7 +82,7 @@ def find_part_of_speech(keyword):
     # TODO: Make this able to handle words with more than one usage
     logging.debug("Looking up \"{0}\" in the dictionary...".format(keyword))
     with connection:
-        cursor.execute('SELECT part_of_speech FROM dictionary WHERE word = \"{0}\";'.format(keyword))
+        cursor.execute('SELECT part_of_speech FROM dictionary WHERE word = ?;', (keyword,))
         SQLReturn = cursor.fetchall()
         if SQLReturn:
             return SQLReturn[0]


### PR DESCRIPTION
Switching to parameterized queries prevents potential SQL injection attacks. I didn't check the entire way strings get parsed by Emma, but there were a few things that seemed questionable. This should avoid all of them by separating the code sqlite sees from the data its sent.

I don't have a local instance of Emma running, so I couldn't test these changes myself, but they're pretty simple so I don't think anything went wrong unless I'm super blind and mistyped and haven't noticed, which is possible.